### PR TITLE
Bump Google.Apis and Google.Apis.Core

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,9 +5,9 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Google.Apis" Version="1.68.0" />
+    <PackageVersion Include="Google.Apis" Version="1.69.0" />
     <PackageVersion Include="Google.Apis.Auth" Version="1.68.0" />
-    <PackageVersion Include="Google.Apis.Core" Version="1.68.0" />
+    <PackageVersion Include="Google.Apis.Core" Version="1.69.0" />
     <PackageVersion Include="Google.Cloud.Speech.V1" Version="2.7.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.28.3" />
     <PackageVersion Include="Google.Protobuf.Tools" Version="3.28.3" />


### PR DESCRIPTION
Bumps [Google.Apis](https://github.com/googleapis/google-api-dotnet-client) and [Google.Apis.Core](https://github.com/googleapis/google-api-dotnet-client). These dependencies needed to be updated together.
Updates `Google.Apis` from 1.68.0 to 1.69.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/googleapis/google-api-dotnet-client/releases">Google.Apis's releases</a>.</em></p>
<blockquote>
<h2>v1.69.0 Several fixes and features</h2>
<p>Fixes:</p>
<ul>
<li><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2869">#2869</a> Use universe-domain instead of universe_domain as the MDS endpoint</li>
<li><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2870">#2870</a> BaseClientService.UniverDomain setter is obsolete</li>
<li><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2871">#2871</a> Pause automatic requests to MDS Universe Domain endpoint</li>
</ul>
<p>Features:</p>
<ul>
<li>
<p><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2746">#2746</a> Simplify setting the HttpClient timeout</p>
</li>
<li>
<p><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2809">#2809</a> Improve error handling when signing with the IAM service</p>
<p>BREAKING CHANGE: The ComputeCredential and ImpersonatedCredential SignBlobAsync methods will throw a GoogleApiException instead of a HttpRequestExtension. The GoogleApiException makes the HttpResponseMessage content available, which usually includes details about the error. We consider the risk of this change breaking users  lower than the risk of disrupting all users with a new major version so we've decided to release this breaking change on a minor version of the library. Please create an issue on this repo if you are affected and we will e happy to help.</p>
</li>
<li>
<p><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2879">#2879</a> Use recommended retries for token and IAM sign blob endpoints</p>
</li>
<li>
<p><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2913">#2913</a> Support GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variable</p>
</li>
</ul>
<p>Dependencies:</p>
<ul>
<li>
<p><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2730">#2730</a> Remove unused dependency Microsoft.AspNetCore.Authorization from Google.Apis.Auth.AspNetCore3</p>
<p>BREAKING CHANGE: Projects using Google.Apis.Auth.AspNetCore3 that transitively depend on Microsoft.AspNetCore.Authorization may be broken. They only need to add an implicit dependency themselves. We consider the risk of this change breaking users  lower than the risk of disrupting all users with a new major version so we've decided to release this breaking change on a minor version of the library. Please create an issue on this repo if you are affected and we will e happy to help.</p>
</li>
</ul>
<p>Documentation:</p>
<ul>
<li><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2916">#2916</a> Add warning note about user provided credential configurations</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/04e805147def8d2ec5b281c97ba77884dc123e0f"><code>04e8051</code></a> Update version 1.68.0 -&gt; 1.69.0</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/ee3ae6865e29dee8ca4aaffd367c059f72a8066b"><code>ee3ae68</code></a> docs: Add warning note about user provided credential configurations.</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/230ac64045f0741040db6afa0dbda8f250506dec"><code>230ac64</code></a> feat: Generate Google.Apis.ServiceControl.v1 version 1.68.0.3669</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/a05298e0d5643ef4a5c5de675ef02084d7053efd"><code>a05298e</code></a> feat: Generate Google.Apis.SecretManager.v1beta1 version 1.68.0.3669</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/84d4aa5414d9330613efab4977d5b9e3250d01ef"><code>84d4aa5</code></a> feat: Generate Google.Apis.SecretManager.v1 version 1.68.0.3669</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/21d64b82fbe325fbb72cfd475d78f26db768be72"><code>21d64b8</code></a> feat: Generate Google.Apis.NetAppFiles.v1beta1 version 1.68.0.3668</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/1cf4901f23b2ae726254372e9ce5a427bd0e1453"><code>1cf4901</code></a> feat: Generate Google.Apis.NetAppFiles.v1 version 1.68.0.3668</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/786b06064217b55a0df0e4c6b9f2618437752ad4"><code>786b060</code></a> feat: Generate Google.Apis.Merchant.conversions_v1beta version 1.68.0.3670</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/f782f2019ee8ffed1d6f9cd91e90a8c68466a129"><code>f782f20</code></a> feat: Generate Google.Apis.FirebaseML.v2beta version 1.68.0.3671</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/5675980c5af9e9a66cfa653a1036f79131cb5057"><code>5675980</code></a> feat: Generate Google.Apis.DataFusion.v1 version 1.68.0.3669</li>
<li>Additional commits viewable in <a href="https://github.com/googleapis/google-api-dotnet-client/compare/v1.68.0...v1.69.0">compare view</a></li>
</ul>
</details>
<br />

Updates `Google.Apis.Core` from 1.68.0 to 1.69.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/googleapis/google-api-dotnet-client/releases">Google.Apis.Core's releases</a>.</em></p>
<blockquote>
<h2>v1.69.0 Several fixes and features</h2>
<p>Fixes:</p>
<ul>
<li><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2869">#2869</a> Use universe-domain instead of universe_domain as the MDS endpoint</li>
<li><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2870">#2870</a> BaseClientService.UniverDomain setter is obsolete</li>
<li><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2871">#2871</a> Pause automatic requests to MDS Universe Domain endpoint</li>
</ul>
<p>Features:</p>
<ul>
<li>
<p><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2746">#2746</a> Simplify setting the HttpClient timeout</p>
</li>
<li>
<p><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2809">#2809</a> Improve error handling when signing with the IAM service</p>
<p>BREAKING CHANGE: The ComputeCredential and ImpersonatedCredential SignBlobAsync methods will throw a GoogleApiException instead of a HttpRequestExtension. The GoogleApiException makes the HttpResponseMessage content available, which usually includes details about the error. We consider the risk of this change breaking users  lower than the risk of disrupting all users with a new major version so we've decided to release this breaking change on a minor version of the library. Please create an issue on this repo if you are affected and we will e happy to help.</p>
</li>
<li>
<p><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2879">#2879</a> Use recommended retries for token and IAM sign blob endpoints</p>
</li>
<li>
<p><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2913">#2913</a> Support GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variable</p>
</li>
</ul>
<p>Dependencies:</p>
<ul>
<li>
<p><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2730">#2730</a> Remove unused dependency Microsoft.AspNetCore.Authorization from Google.Apis.Auth.AspNetCore3</p>
<p>BREAKING CHANGE: Projects using Google.Apis.Auth.AspNetCore3 that transitively depend on Microsoft.AspNetCore.Authorization may be broken. They only need to add an implicit dependency themselves. We consider the risk of this change breaking users  lower than the risk of disrupting all users with a new major version so we've decided to release this breaking change on a minor version of the library. Please create an issue on this repo if you are affected and we will e happy to help.</p>
</li>
</ul>
<p>Documentation:</p>
<ul>
<li><a href="https://redirect.github.com/googleapis/google-api-dotnet-client/issues/2916">#2916</a> Add warning note about user provided credential configurations</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/04e805147def8d2ec5b281c97ba77884dc123e0f"><code>04e8051</code></a> Update version 1.68.0 -&gt; 1.69.0</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/ee3ae6865e29dee8ca4aaffd367c059f72a8066b"><code>ee3ae68</code></a> docs: Add warning note about user provided credential configurations.</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/230ac64045f0741040db6afa0dbda8f250506dec"><code>230ac64</code></a> feat: Generate Google.Apis.ServiceControl.v1 version 1.68.0.3669</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/a05298e0d5643ef4a5c5de675ef02084d7053efd"><code>a05298e</code></a> feat: Generate Google.Apis.SecretManager.v1beta1 version 1.68.0.3669</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/84d4aa5414d9330613efab4977d5b9e3250d01ef"><code>84d4aa5</code></a> feat: Generate Google.Apis.SecretManager.v1 version 1.68.0.3669</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/21d64b82fbe325fbb72cfd475d78f26db768be72"><code>21d64b8</code></a> feat: Generate Google.Apis.NetAppFiles.v1beta1 version 1.68.0.3668</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/1cf4901f23b2ae726254372e9ce5a427bd0e1453"><code>1cf4901</code></a> feat: Generate Google.Apis.NetAppFiles.v1 version 1.68.0.3668</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/786b06064217b55a0df0e4c6b9f2618437752ad4"><code>786b060</code></a> feat: Generate Google.Apis.Merchant.conversions_v1beta version 1.68.0.3670</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/f782f2019ee8ffed1d6f9cd91e90a8c68466a129"><code>f782f20</code></a> feat: Generate Google.Apis.FirebaseML.v2beta version 1.68.0.3671</li>
<li><a href="https://github.com/googleapis/google-api-dotnet-client/commit/5675980c5af9e9a66cfa653a1036f79131cb5057"><code>5675980</code></a> feat: Generate Google.Apis.DataFusion.v1 version 1.68.0.3669</li>
<li>Additional commits viewable in <a href="https://github.com/googleapis/google-api-dotnet-client/compare/v1.68.0...v1.69.0">compare view</a></li>
</ul>
</details>
<br />
