### PR TITLE
Bump Grpc.AspNetCore, Grpc.Core.Api, Grpc.Net.Client and Grpc.Net.ClientFactory

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,16 +11,16 @@
     <PackageVersion Include="Google.Cloud.Speech.V1" Version="2.7.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.28.3" />
     <PackageVersion Include="Google.Protobuf.Tools" Version="3.28.3" />
-    <PackageVersion Include="Grpc.AspNetCore" Version="2.59.0" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.70.0" />
     <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="2.59.0" />
     <PackageVersion Include="Grpc.AspNetCore.HealthChecks" Version="2.59.0" />
     <PackageVersion Include="Grpc.Core" Version="2.46.6" />
-    <PackageVersion Include="Grpc.Core.Api" Version="2.65.0" />
+    <PackageVersion Include="Grpc.Core.Api" Version="2.70.0" />
     <PackageVersion Include="Grpc.Core.Testing" Version="2.46.6" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.65.0" />
-    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.65.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.70.0" />
+    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.70.0" />
     <PackageVersion Include="Grpc.Reflection" Version="2.59.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.59.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.70.0" />
   </ItemGroup>
   <!-- TargetFrameworks need to be checked on ItemGroups. -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">


### PR DESCRIPTION
Bumps [Grpc.AspNetCore](https://github.com/grpc/grpc-dotnet), [Grpc.Core.Api](https://github.com/grpc/grpc-dotnet), [Grpc.Net.Client](https://github.com/grpc/grpc-dotnet) and [Grpc.Net.ClientFactory](https://github.com/grpc/grpc-dotnet). These dependencies needed to be updated together.
Updates `Grpc.AspNetCore` from 2.59.0 to 2.70.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/grpc/grpc-dotnet/releases">Grpc.AspNetCore's releases</a>.</em></p>
<blockquote>
<h2>Release v2.70.0</h2>
<h2>What's Changed</h2>
<ul>
<li>update ArgumentNullException.ThrowIfNull usage by <a href="https://github.com/WeihanLi"><code>@​WeihanLi</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2563">grpc/grpc-dotnet#2563</a></li>
<li>use nameof for CallerArgumentExpression by <a href="https://github.com/WeihanLi"><code>@​WeihanLi</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2562">grpc/grpc-dotnet#2562</a></li>
<li>Correctness: Make some private &amp; internal classes sealed where possible by <a href="https://github.com/Henr1k80"><code>@​Henr1k80</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2559">grpc/grpc-dotnet#2559</a></li>
<li>Bump vue from 2.6.14 to 3.0.0 in /examples/Spar/Server/ClientApp by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2565">grpc/grpc-dotnet#2565</a></li>
<li>Bump cross-spawn from 7.0.3 to 7.0.6 in /testassets/InteropTestsGrpcWebWebsite/Tests by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2574">grpc/grpc-dotnet#2574</a></li>
<li>[vote]Added Active maintainers into MAINTAINERS.md. by <a href="https://github.com/subhraOffGit"><code>@​subhraOffGit</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2449">grpc/grpc-dotnet#2449</a></li>
<li>Refactor: Use <code>await using</code> for <code>packageVersionStream</code> to ensure proper disposal of async resources by <a href="https://github.com/dexcompiler"><code>@​dexcompiler</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2521">grpc/grpc-dotnet#2521</a></li>
<li>Performance microoptimizations by <a href="https://github.com/Henr1k80"><code>@​Henr1k80</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2558">grpc/grpc-dotnet#2558</a></li>
<li>Complete health checks watch service on server shutting down by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2582">grpc/grpc-dotnet#2582</a></li>
<li>Avoid using ConcurrentDictionary for channels with few methods by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2597">grpc/grpc-dotnet#2597</a></li>
<li>Bump elliptic from 6.6.0 to 6.6.1 in /examples/Spar/Server/ClientApp by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2599">grpc/grpc-dotnet#2599</a></li>
<li>Move updating connectivity state outside of subchannel lock by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2601">grpc/grpc-dotnet#2601</a></li>
<li>Bump Grpc.Tools dependency by <a href="https://github.com/apolcyn"><code>@​apolcyn</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2603">grpc/grpc-dotnet#2603</a></li>
<li>bump version on v2.70.x branch by <a href="https://github.com/apolcyn"><code>@​apolcyn</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2604">grpc/grpc-dotnet#2604</a></li>
<li>Change version to 2.70.0 by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2610">grpc/grpc-dotnet#2610</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/Henr1k80"><code>@​Henr1k80</code></a> made their first contribution in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2559">grpc/grpc-dotnet#2559</a></li>
<li><a href="https://github.com/subhraOffGit"><code>@​subhraOffGit</code></a> made their first contribution in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2449">grpc/grpc-dotnet#2449</a></li>
<li><a href="https://github.com/dexcompiler"><code>@​dexcompiler</code></a> made their first contribution in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2521">grpc/grpc-dotnet#2521</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/grpc/grpc-dotnet/compare/v2.67.0...v2.70.0">https://github.com/grpc/grpc-dotnet/compare/v2.67.0...v2.70.0</a></p>
<h2>Release v2.67.0</h2>
<h2>What's Changed</h2>
<ul>
<li>precompile condition clean by <a href="https://github.com/Varorbc"><code>@​Varorbc</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2528">grpc/grpc-dotnet#2528</a></li>
<li>Log server cancellation errors at info level by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2527">grpc/grpc-dotnet#2527</a></li>
<li>Update logging to use generated logs by <a href="https://github.com/wabalubdub"><code>@​wabalubdub</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2531">grpc/grpc-dotnet#2531</a></li>
<li>Bump serve-static from 1.14.2 to 1.16.2 in /examples/Spar/Server/ClientApp by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2536">grpc/grpc-dotnet#2536</a></li>
<li>Update to Grpc.Tools 2.67.0-pre1 by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2547">grpc/grpc-dotnet#2547</a></li>
<li>Cleanup gRPC unit testing helpers in tester sample by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2548">grpc/grpc-dotnet#2548</a></li>
<li>Fix UpdateBalancingState not called when address attributes are modified by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2553">grpc/grpc-dotnet#2553</a></li>
<li>Update Grpc.Tools to 2.67.0 by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2554">grpc/grpc-dotnet#2554</a></li>
<li>Fix System.Text.Json vulnerability warning by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2556">grpc/grpc-dotnet#2556</a></li>
<li>Update package dependencies to 9.0 RC2 by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2560">grpc/grpc-dotnet#2560</a></li>
<li>Bump elliptic from 6.5.7 to 6.6.0 in /examples/Spar/Server/ClientApp by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2567">grpc/grpc-dotnet#2567</a></li>
<li>Update to .NET 9 RTM by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2571">grpc/grpc-dotnet#2571</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/wabalubdub"><code>@​wabalubdub</code></a> made their first contribution in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2531">grpc/grpc-dotnet#2531</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/grpc/grpc-dotnet/compare/v2.66.0...v2.67.0">https://github.com/grpc/grpc-dotnet/compare/v2.66.0...v2.67.0</a></p>
<h2>Release v2.67.0-pre1</h2>
<h2>What's Changed</h2>
<ul>
<li>precompile condition clean by <a href="https://github.com/Varorbc"><code>@​Varorbc</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2528">grpc/grpc-dotnet#2528</a></li>
<li>Log server cancellation errors at info level by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2527">grpc/grpc-dotnet#2527</a></li>
<li>Update logging to use generated logs by <a href="https://github.com/wabalubdub"><code>@​wabalubdub</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2531">grpc/grpc-dotnet#2531</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/8fa80f0dfc72a870227c77e0fa25855f34a84464"><code>8fa80f0</code></a> Change version to 2.70.0 (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2610">#2610</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/cae7568fca9526be175b85c729f45d1533157ee5"><code>cae7568</code></a> bump version on v2.70.x branch (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2604">#2604</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/147a4647ad43a4107e38c414e271dbecceefc999"><code>147a464</code></a> bump Grpc.Tools dep (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2603">#2603</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/852a118c7b97afc23fae45166b2fa2bd6943c468"><code>852a118</code></a> Move updating connectivity state outside of subchannel lock (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2601">#2601</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/60d9d2ce15c117ed9eaed6e2737bb635728c5c04"><code>60d9d2c</code></a> Bump elliptic from 6.6.0 to 6.6.1 in /examples/Spar/Server/ClientApp (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2599">#2599</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/a2f7d06e02ae710143ff820ca14911bb9c8906e7"><code>a2f7d06</code></a> Avoid using ConcurrentDictionary for channels with few methods (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2597">#2597</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/c9d26719e8b2a8f03424cacbb168540e35a94b0b"><code>c9d2671</code></a> Complete health checks watch service on server shutting down (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2582">#2582</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/b7af033360155835fede1f042f6e45cc3ce94aa0"><code>b7af033</code></a> Performance microoptimizations (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2558">#2558</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/6a3c9774f651b2d5ab0b92a8987732f0a6643b25"><code>6a3c977</code></a> Refactor: Use <code>await using</code> for <code>packageVersionStream</code> to ensure proper dispo...</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/cacf59d94227f338ac12cbbb47187118277f433d"><code>cacf59d</code></a> [vote]Added Active maintainers into MAINTAINERS.md. (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2449">#2449</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/grpc/grpc-dotnet/compare/v2.59.0...v2.70.0">compare view</a></li>
</ul>
</details>
<br />

Updates `Grpc.Core.Api` from 2.65.0 to 2.70.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/grpc/grpc-dotnet/releases">Grpc.Core.Api's releases</a>.</em></p>
<blockquote>
<h2>Release v2.70.0</h2>
<h2>What's Changed</h2>
<ul>
<li>update ArgumentNullException.ThrowIfNull usage by <a href="https://github.com/WeihanLi"><code>@​WeihanLi</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2563">grpc/grpc-dotnet#2563</a></li>
<li>use nameof for CallerArgumentExpression by <a href="https://github.com/WeihanLi"><code>@​WeihanLi</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2562">grpc/grpc-dotnet#2562</a></li>
<li>Correctness: Make some private &amp; internal classes sealed where possible by <a href="https://github.com/Henr1k80"><code>@​Henr1k80</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2559">grpc/grpc-dotnet#2559</a></li>
<li>Bump vue from 2.6.14 to 3.0.0 in /examples/Spar/Server/ClientApp by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2565">grpc/grpc-dotnet#2565</a></li>
<li>Bump cross-spawn from 7.0.3 to 7.0.6 in /testassets/InteropTestsGrpcWebWebsite/Tests by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2574">grpc/grpc-dotnet#2574</a></li>
<li>[vote]Added Active maintainers into MAINTAINERS.md. by <a href="https://github.com/subhraOffGit"><code>@​subhraOffGit</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2449">grpc/grpc-dotnet#2449</a></li>
<li>Refactor: Use <code>await using</code> for <code>packageVersionStream</code> to ensure proper disposal of async resources by <a href="https://github.com/dexcompiler"><code>@​dexcompiler</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2521">grpc/grpc-dotnet#2521</a></li>
<li>Performance microoptimizations by <a href="https://github.com/Henr1k80"><code>@​Henr1k80</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2558">grpc/grpc-dotnet#2558</a></li>
<li>Complete health checks watch service on server shutting down by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2582">grpc/grpc-dotnet#2582</a></li>
<li>Avoid using ConcurrentDictionary for channels with few methods by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2597">grpc/grpc-dotnet#2597</a></li>
<li>Bump elliptic from 6.6.0 to 6.6.1 in /examples/Spar/Server/ClientApp by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2599">grpc/grpc-dotnet#2599</a></li>
<li>Move updating connectivity state outside of subchannel lock by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2601">grpc/grpc-dotnet#2601</a></li>
<li>Bump Grpc.Tools dependency by <a href="https://github.com/apolcyn"><code>@​apolcyn</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2603">grpc/grpc-dotnet#2603</a></li>
<li>bump version on v2.70.x branch by <a href="https://github.com/apolcyn"><code>@​apolcyn</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2604">grpc/grpc-dotnet#2604</a></li>
<li>Change version to 2.70.0 by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2610">grpc/grpc-dotnet#2610</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/Henr1k80"><code>@​Henr1k80</code></a> made their first contribution in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2559">grpc/grpc-dotnet#2559</a></li>
<li><a href="https://github.com/subhraOffGit"><code>@​subhraOffGit</code></a> made their first contribution in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2449">grpc/grpc-dotnet#2449</a></li>
<li><a href="https://github.com/dexcompiler"><code>@​dexcompiler</code></a> made their first contribution in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2521">grpc/grpc-dotnet#2521</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/grpc/grpc-dotnet/compare/v2.67.0...v2.70.0">https://github.com/grpc/grpc-dotnet/compare/v2.67.0...v2.70.0</a></p>
<h2>Release v2.67.0</h2>
<h2>What's Changed</h2>
<ul>
<li>precompile condition clean by <a href="https://github.com/Varorbc"><code>@​Varorbc</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2528">grpc/grpc-dotnet#2528</a></li>
<li>Log server cancellation errors at info level by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2527">grpc/grpc-dotnet#2527</a></li>
<li>Update logging to use generated logs by <a href="https://github.com/wabalubdub"><code>@​wabalubdub</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2531">grpc/grpc-dotnet#2531</a></li>
<li>Bump serve-static from 1.14.2 to 1.16.2 in /examples/Spar/Server/ClientApp by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2536">grpc/grpc-dotnet#2536</a></li>
<li>Update to Grpc.Tools 2.67.0-pre1 by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2547">grpc/grpc-dotnet#2547</a></li>
<li>Cleanup gRPC unit testing helpers in tester sample by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2548">grpc/grpc-dotnet#2548</a></li>
<li>Fix UpdateBalancingState not called when address attributes are modified by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2553">grpc/grpc-dotnet#2553</a></li>
<li>Update Grpc.Tools to 2.67.0 by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2554">grpc/grpc-dotnet#2554</a></li>
<li>Fix System.Text.Json vulnerability warning by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2556">grpc/grpc-dotnet#2556</a></li>
<li>Update package dependencies to 9.0 RC2 by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2560">grpc/grpc-dotnet#2560</a></li>
<li>Bump elliptic from 6.5.7 to 6.6.0 in /examples/Spar/Server/ClientApp by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2567">grpc/grpc-dotnet#2567</a></li>
<li>Update to .NET 9 RTM by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2571">grpc/grpc-dotnet#2571</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/wabalubdub"><code>@​wabalubdub</code></a> made their first contribution in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2531">grpc/grpc-dotnet#2531</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/grpc/grpc-dotnet/compare/v2.66.0...v2.67.0">https://github.com/grpc/grpc-dotnet/compare/v2.66.0...v2.67.0</a></p>
<h2>Release v2.67.0-pre1</h2>
<h2>What's Changed</h2>
<ul>
<li>precompile condition clean by <a href="https://github.com/Varorbc"><code>@​Varorbc</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2528">grpc/grpc-dotnet#2528</a></li>
<li>Log server cancellation errors at info level by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2527">grpc/grpc-dotnet#2527</a></li>
<li>Update logging to use generated logs by <a href="https://github.com/wabalubdub"><code>@​wabalubdub</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2531">grpc/grpc-dotnet#2531</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/8fa80f0dfc72a870227c77e0fa25855f34a84464"><code>8fa80f0</code></a> Change version to 2.70.0 (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2610">#2610</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/cae7568fca9526be175b85c729f45d1533157ee5"><code>cae7568</code></a> bump version on v2.70.x branch (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2604">#2604</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/147a4647ad43a4107e38c414e271dbecceefc999"><code>147a464</code></a> bump Grpc.Tools dep (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2603">#2603</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/852a118c7b97afc23fae45166b2fa2bd6943c468"><code>852a118</code></a> Move updating connectivity state outside of subchannel lock (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2601">#2601</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/60d9d2ce15c117ed9eaed6e2737bb635728c5c04"><code>60d9d2c</code></a> Bump elliptic from 6.6.0 to 6.6.1 in /examples/Spar/Server/ClientApp (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2599">#2599</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/a2f7d06e02ae710143ff820ca14911bb9c8906e7"><code>a2f7d06</code></a> Avoid using ConcurrentDictionary for channels with few methods (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2597">#2597</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/c9d26719e8b2a8f03424cacbb168540e35a94b0b"><code>c9d2671</code></a> Complete health checks watch service on server shutting down (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2582">#2582</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/b7af033360155835fede1f042f6e45cc3ce94aa0"><code>b7af033</code></a> Performance microoptimizations (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2558">#2558</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/6a3c9774f651b2d5ab0b92a8987732f0a6643b25"><code>6a3c977</code></a> Refactor: Use <code>await using</code> for <code>packageVersionStream</code> to ensure proper dispo...</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/cacf59d94227f338ac12cbbb47187118277f433d"><code>cacf59d</code></a> [vote]Added Active maintainers into MAINTAINERS.md. (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2449">#2449</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/grpc/grpc-dotnet/compare/v2.65.0...v2.70.0">compare view</a></li>
</ul>
</details>
<br />

Updates `Grpc.Net.Client` from 2.65.0 to 2.70.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/grpc/grpc-dotnet/releases">Grpc.Net.Client's releases</a>.</em></p>
<blockquote>
<h2>Release v2.70.0</h2>
<h2>What's Changed</h2>
<ul>
<li>update ArgumentNullException.ThrowIfNull usage by <a href="https://github.com/WeihanLi"><code>@​WeihanLi</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2563">grpc/grpc-dotnet#2563</a></li>
<li>use nameof for CallerArgumentExpression by <a href="https://github.com/WeihanLi"><code>@​WeihanLi</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2562">grpc/grpc-dotnet#2562</a></li>
<li>Correctness: Make some private &amp; internal classes sealed where possible by <a href="https://github.com/Henr1k80"><code>@​Henr1k80</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2559">grpc/grpc-dotnet#2559</a></li>
<li>Bump vue from 2.6.14 to 3.0.0 in /examples/Spar/Server/ClientApp by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2565">grpc/grpc-dotnet#2565</a></li>
<li>Bump cross-spawn from 7.0.3 to 7.0.6 in /testassets/InteropTestsGrpcWebWebsite/Tests by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2574">grpc/grpc-dotnet#2574</a></li>
<li>[vote]Added Active maintainers into MAINTAINERS.md. by <a href="https://github.com/subhraOffGit"><code>@​subhraOffGit</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2449">grpc/grpc-dotnet#2449</a></li>
<li>Refactor: Use <code>await using</code> for <code>packageVersionStream</code> to ensure proper disposal of async resources by <a href="https://github.com/dexcompiler"><code>@​dexcompiler</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2521">grpc/grpc-dotnet#2521</a></li>
<li>Performance microoptimizations by <a href="https://github.com/Henr1k80"><code>@​Henr1k80</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2558">grpc/grpc-dotnet#2558</a></li>
<li>Complete health checks watch service on server shutting down by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2582">grpc/grpc-dotnet#2582</a></li>
<li>Avoid using ConcurrentDictionary for channels with few methods by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2597">grpc/grpc-dotnet#2597</a></li>
<li>Bump elliptic from 6.6.0 to 6.6.1 in /examples/Spar/Server/ClientApp by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2599">grpc/grpc-dotnet#2599</a></li>
<li>Move updating connectivity state outside of subchannel lock by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2601">grpc/grpc-dotnet#2601</a></li>
<li>Bump Grpc.Tools dependency by <a href="https://github.com/apolcyn"><code>@​apolcyn</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2603">grpc/grpc-dotnet#2603</a></li>
<li>bump version on v2.70.x branch by <a href="https://github.com/apolcyn"><code>@​apolcyn</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2604">grpc/grpc-dotnet#2604</a></li>
<li>Change version to 2.70.0 by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2610">grpc/grpc-dotnet#2610</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/Henr1k80"><code>@​Henr1k80</code></a> made their first contribution in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2559">grpc/grpc-dotnet#2559</a></li>
<li><a href="https://github.com/subhraOffGit"><code>@​subhraOffGit</code></a> made their first contribution in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2449">grpc/grpc-dotnet#2449</a></li>
<li><a href="https://github.com/dexcompiler"><code>@​dexcompiler</code></a> made their first contribution in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2521">grpc/grpc-dotnet#2521</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/grpc/grpc-dotnet/compare/v2.67.0...v2.70.0">https://github.com/grpc/grpc-dotnet/compare/v2.67.0...v2.70.0</a></p>
<h2>Release v2.67.0</h2>
<h2>What's Changed</h2>
<ul>
<li>precompile condition clean by <a href="https://github.com/Varorbc"><code>@​Varorbc</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2528">grpc/grpc-dotnet#2528</a></li>
<li>Log server cancellation errors at info level by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2527">grpc/grpc-dotnet#2527</a></li>
<li>Update logging to use generated logs by <a href="https://github.com/wabalubdub"><code>@​wabalubdub</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2531">grpc/grpc-dotnet#2531</a></li>
<li>Bump serve-static from 1.14.2 to 1.16.2 in /examples/Spar/Server/ClientApp by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2536">grpc/grpc-dotnet#2536</a></li>
<li>Update to Grpc.Tools 2.67.0-pre1 by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2547">grpc/grpc-dotnet#2547</a></li>
<li>Cleanup gRPC unit testing helpers in tester sample by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2548">grpc/grpc-dotnet#2548</a></li>
<li>Fix UpdateBalancingState not called when address attributes are modified by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2553">grpc/grpc-dotnet#2553</a></li>
<li>Update Grpc.Tools to 2.67.0 by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2554">grpc/grpc-dotnet#2554</a></li>
<li>Fix System.Text.Json vulnerability warning by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2556">grpc/grpc-dotnet#2556</a></li>
<li>Update package dependencies to 9.0 RC2 by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2560">grpc/grpc-dotnet#2560</a></li>
<li>Bump elliptic from 6.5.7 to 6.6.0 in /examples/Spar/Server/ClientApp by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2567">grpc/grpc-dotnet#2567</a></li>
<li>Update to .NET 9 RTM by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2571">grpc/grpc-dotnet#2571</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/wabalubdub"><code>@​wabalubdub</code></a> made their first contribution in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2531">grpc/grpc-dotnet#2531</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/grpc/grpc-dotnet/compare/v2.66.0...v2.67.0">https://github.com/grpc/grpc-dotnet/compare/v2.66.0...v2.67.0</a></p>
<h2>Release v2.67.0-pre1</h2>
<h2>What's Changed</h2>
<ul>
<li>precompile condition clean by <a href="https://github.com/Varorbc"><code>@​Varorbc</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2528">grpc/grpc-dotnet#2528</a></li>
<li>Log server cancellation errors at info level by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2527">grpc/grpc-dotnet#2527</a></li>
<li>Update logging to use generated logs by <a href="https://github.com/wabalubdub"><code>@​wabalubdub</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2531">grpc/grpc-dotnet#2531</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/8fa80f0dfc72a870227c77e0fa25855f34a84464"><code>8fa80f0</code></a> Change version to 2.70.0 (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2610">#2610</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/cae7568fca9526be175b85c729f45d1533157ee5"><code>cae7568</code></a> bump version on v2.70.x branch (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2604">#2604</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/147a4647ad43a4107e38c414e271dbecceefc999"><code>147a464</code></a> bump Grpc.Tools dep (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2603">#2603</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/852a118c7b97afc23fae45166b2fa2bd6943c468"><code>852a118</code></a> Move updating connectivity state outside of subchannel lock (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2601">#2601</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/60d9d2ce15c117ed9eaed6e2737bb635728c5c04"><code>60d9d2c</code></a> Bump elliptic from 6.6.0 to 6.6.1 in /examples/Spar/Server/ClientApp (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2599">#2599</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/a2f7d06e02ae710143ff820ca14911bb9c8906e7"><code>a2f7d06</code></a> Avoid using ConcurrentDictionary for channels with few methods (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2597">#2597</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/c9d26719e8b2a8f03424cacbb168540e35a94b0b"><code>c9d2671</code></a> Complete health checks watch service on server shutting down (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2582">#2582</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/b7af033360155835fede1f042f6e45cc3ce94aa0"><code>b7af033</code></a> Performance microoptimizations (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2558">#2558</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/6a3c9774f651b2d5ab0b92a8987732f0a6643b25"><code>6a3c977</code></a> Refactor: Use <code>await using</code> for <code>packageVersionStream</code> to ensure proper dispo...</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/cacf59d94227f338ac12cbbb47187118277f433d"><code>cacf59d</code></a> [vote]Added Active maintainers into MAINTAINERS.md. (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2449">#2449</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/grpc/grpc-dotnet/compare/v2.65.0...v2.70.0">compare view</a></li>
</ul>
</details>
<br />

Updates `Grpc.Net.ClientFactory` from 2.65.0 to 2.70.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/grpc/grpc-dotnet/releases">Grpc.Net.ClientFactory's releases</a>.</em></p>
<blockquote>
<h2>Release v2.70.0</h2>
<h2>What's Changed</h2>
<ul>
<li>update ArgumentNullException.ThrowIfNull usage by <a href="https://github.com/WeihanLi"><code>@​WeihanLi</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2563">grpc/grpc-dotnet#2563</a></li>
<li>use nameof for CallerArgumentExpression by <a href="https://github.com/WeihanLi"><code>@​WeihanLi</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2562">grpc/grpc-dotnet#2562</a></li>
<li>Correctness: Make some private &amp; internal classes sealed where possible by <a href="https://github.com/Henr1k80"><code>@​Henr1k80</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2559">grpc/grpc-dotnet#2559</a></li>
<li>Bump vue from 2.6.14 to 3.0.0 in /examples/Spar/Server/ClientApp by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2565">grpc/grpc-dotnet#2565</a></li>
<li>Bump cross-spawn from 7.0.3 to 7.0.6 in /testassets/InteropTestsGrpcWebWebsite/Tests by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2574">grpc/grpc-dotnet#2574</a></li>
<li>[vote]Added Active maintainers into MAINTAINERS.md. by <a href="https://github.com/subhraOffGit"><code>@​subhraOffGit</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2449">grpc/grpc-dotnet#2449</a></li>
<li>Refactor: Use <code>await using</code> for <code>packageVersionStream</code> to ensure proper disposal of async resources by <a href="https://github.com/dexcompiler"><code>@​dexcompiler</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2521">grpc/grpc-dotnet#2521</a></li>
<li>Performance microoptimizations by <a href="https://github.com/Henr1k80"><code>@​Henr1k80</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2558">grpc/grpc-dotnet#2558</a></li>
<li>Complete health checks watch service on server shutting down by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2582">grpc/grpc-dotnet#2582</a></li>
<li>Avoid using ConcurrentDictionary for channels with few methods by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2597">grpc/grpc-dotnet#2597</a></li>
<li>Bump elliptic from 6.6.0 to 6.6.1 in /examples/Spar/Server/ClientApp by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2599">grpc/grpc-dotnet#2599</a></li>
<li>Move updating connectivity state outside of subchannel lock by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2601">grpc/grpc-dotnet#2601</a></li>
<li>Bump Grpc.Tools dependency by <a href="https://github.com/apolcyn"><code>@​apolcyn</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2603">grpc/grpc-dotnet#2603</a></li>
<li>bump version on v2.70.x branch by <a href="https://github.com/apolcyn"><code>@​apolcyn</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2604">grpc/grpc-dotnet#2604</a></li>
<li>Change version to 2.70.0 by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2610">grpc/grpc-dotnet#2610</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/Henr1k80"><code>@​Henr1k80</code></a> made their first contribution in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2559">grpc/grpc-dotnet#2559</a></li>
<li><a href="https://github.com/subhraOffGit"><code>@​subhraOffGit</code></a> made their first contribution in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2449">grpc/grpc-dotnet#2449</a></li>
<li><a href="https://github.com/dexcompiler"><code>@​dexcompiler</code></a> made their first contribution in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2521">grpc/grpc-dotnet#2521</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/grpc/grpc-dotnet/compare/v2.67.0...v2.70.0">https://github.com/grpc/grpc-dotnet/compare/v2.67.0...v2.70.0</a></p>
<h2>Release v2.67.0</h2>
<h2>What's Changed</h2>
<ul>
<li>precompile condition clean by <a href="https://github.com/Varorbc"><code>@​Varorbc</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2528">grpc/grpc-dotnet#2528</a></li>
<li>Log server cancellation errors at info level by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2527">grpc/grpc-dotnet#2527</a></li>
<li>Update logging to use generated logs by <a href="https://github.com/wabalubdub"><code>@​wabalubdub</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2531">grpc/grpc-dotnet#2531</a></li>
<li>Bump serve-static from 1.14.2 to 1.16.2 in /examples/Spar/Server/ClientApp by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2536">grpc/grpc-dotnet#2536</a></li>
<li>Update to Grpc.Tools 2.67.0-pre1 by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2547">grpc/grpc-dotnet#2547</a></li>
<li>Cleanup gRPC unit testing helpers in tester sample by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2548">grpc/grpc-dotnet#2548</a></li>
<li>Fix UpdateBalancingState not called when address attributes are modified by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2553">grpc/grpc-dotnet#2553</a></li>
<li>Update Grpc.Tools to 2.67.0 by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2554">grpc/grpc-dotnet#2554</a></li>
<li>Fix System.Text.Json vulnerability warning by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2556">grpc/grpc-dotnet#2556</a></li>
<li>Update package dependencies to 9.0 RC2 by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2560">grpc/grpc-dotnet#2560</a></li>
<li>Bump elliptic from 6.5.7 to 6.6.0 in /examples/Spar/Server/ClientApp by <a href="https://github.com/dependabot"><code>@​dependabot</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2567">grpc/grpc-dotnet#2567</a></li>
<li>Update to .NET 9 RTM by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2571">grpc/grpc-dotnet#2571</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/wabalubdub"><code>@​wabalubdub</code></a> made their first contribution in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2531">grpc/grpc-dotnet#2531</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/grpc/grpc-dotnet/compare/v2.66.0...v2.67.0">https://github.com/grpc/grpc-dotnet/compare/v2.66.0...v2.67.0</a></p>
<h2>Release v2.67.0-pre1</h2>
<h2>What's Changed</h2>
<ul>
<li>precompile condition clean by <a href="https://github.com/Varorbc"><code>@​Varorbc</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2528">grpc/grpc-dotnet#2528</a></li>
<li>Log server cancellation errors at info level by <a href="https://github.com/JamesNK"><code>@​JamesNK</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2527">grpc/grpc-dotnet#2527</a></li>
<li>Update logging to use generated logs by <a href="https://github.com/wabalubdub"><code>@​wabalubdub</code></a> in <a href="https://redirect.github.com/grpc/grpc-dotnet/pull/2531">grpc/grpc-dotnet#2531</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/8fa80f0dfc72a870227c77e0fa25855f34a84464"><code>8fa80f0</code></a> Change version to 2.70.0 (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2610">#2610</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/cae7568fca9526be175b85c729f45d1533157ee5"><code>cae7568</code></a> bump version on v2.70.x branch (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2604">#2604</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/147a4647ad43a4107e38c414e271dbecceefc999"><code>147a464</code></a> bump Grpc.Tools dep (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2603">#2603</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/852a118c7b97afc23fae45166b2fa2bd6943c468"><code>852a118</code></a> Move updating connectivity state outside of subchannel lock (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2601">#2601</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/60d9d2ce15c117ed9eaed6e2737bb635728c5c04"><code>60d9d2c</code></a> Bump elliptic from 6.6.0 to 6.6.1 in /examples/Spar/Server/ClientApp (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2599">#2599</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/a2f7d06e02ae710143ff820ca14911bb9c8906e7"><code>a2f7d06</code></a> Avoid using ConcurrentDictionary for channels with few methods (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2597">#2597</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/c9d26719e8b2a8f03424cacbb168540e35a94b0b"><code>c9d2671</code></a> Complete health checks watch service on server shutting down (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2582">#2582</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/b7af033360155835fede1f042f6e45cc3ce94aa0"><code>b7af033</code></a> Performance microoptimizations (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2558">#2558</a>)</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/6a3c9774f651b2d5ab0b92a8987732f0a6643b25"><code>6a3c977</code></a> Refactor: Use <code>await using</code> for <code>packageVersionStream</code> to ensure proper dispo...</li>
<li><a href="https://github.com/grpc/grpc-dotnet/commit/cacf59d94227f338ac12cbbb47187118277f433d"><code>cacf59d</code></a> [vote]Added Active maintainers into MAINTAINERS.md. (<a href="https://redirect.github.com/grpc/grpc-dotnet/issues/2449">#2449</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/grpc/grpc-dotnet/compare/v2.65.0...v2.70.0">compare view</a></li>
</ul>
</details>
<br />
